### PR TITLE
Adjust publish org to org.virtuslab.scala-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "v*"
   pull_request:

--- a/build.sc
+++ b/build.sc
@@ -220,7 +220,7 @@ trait ScalaJsCliPublishModule extends PublishModule {
   import mill.scalalib.publish._
   def pomSettings = PomSettings(
     description = artifactName(),
-    organization = "io.github.alexarchambault.tmp",
+    organization = "org.virtuslab.scala-cli",
     url = s"https://github.com/$ghOrg/$ghName",
     licenses = Seq(License.`BSD-3-Clause`),
     versionControl = VersionControl.github(ghOrg, ghName),
@@ -324,8 +324,8 @@ object ci extends Module {
       set.head
     }
     val publisher = new scalalib.publish.SonatypePublisher(
-      uri = "https://s01.oss.sonatype.org/service/local",
-      snapshotUri = "https://s01.oss.sonatype.org/content/repositories/snapshots",
+      uri = "https://oss.sonatype.org/service/local",
+      snapshotUri = "https://oss.sonatype.org/content/repositories/snapshots",
       credentials = credentials,
       signed = true,
       // format: off

--- a/build.sc
+++ b/build.sc
@@ -363,6 +363,8 @@ object ci extends Module {
       else ("v" + version, false)
 
     Upload.upload("scala-cli", "scala-js-cli", ghToken, tag, dryRun = false, overwrite = overwriteAssets)(launchers: _*)
+    if(version != scalaJsVersion) // when we release `0.13.0.1` we should also update native launchers in tag `0.13.0`
+      Upload.upload("scala-cli", "scala-js-cli", ghToken, s"v$scalaJsVersion", dryRun = false, overwrite = true)(launchers: _*)
   }
 }
 


### PR DESCRIPTION
- [Adjust publish org to org.virtuslab.scala-cli](https://github.com/VirtusLab/scala-js-cli/pull/8/commits/eca3f51c1668dfb8595186238971a5e8df3f90b7) - publish to maven central using virtuslab credential
- [Fix - allow to run CI on main branch](https://github.com/VirtusLab/scala-js-cli/pull/8/commits/bf1aac4012f643fad6d1985462c877cc45bb17f2) - enable to run CI on `main` branch
- [Upload native launcher of scalajs-cli into tag with the same version](https://github.com/VirtusLab/scala-js-cli/pull/8/commits/0cb7e27d518596667cd4e6b2259f5cc133d8417d) - In scala-cli we will download scalajs-cli using the following dependency:
```
org.virtuslab.scala-cli:scalajs-cli:1.13.0+
```
It allows to introduce some fixes into `scalajs-cli` and not require any update of scala-cli to have the newest version of `scalajs-cli` for specific version of Scala.js

But for release assets we are not able to use the above syntax for downloading launchers, so we push native launcher with updates to tag with the version of Scala.js

