### PR TITLE
Bump Scala.js to 1.18.2

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -18,7 +18,7 @@ import scala.util.Properties.isWin
 
 def scalaJsCliVersion = "1.1.1-sc5"
 def scala213 = "2.13.16"
-def scalaJsVersion = "1.18.1"
+def scalaJsVersion = "1.18.2"
 object cli extends Cli
 trait Cli extends ScalaModule with ScalaJsCliPublishModule {
   def scalaVersion = scala213


### PR DESCRIPTION
https://github.com/scala-js/scala-js/releases/tag/v1.18.2