### PR TITLE
Bump github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           @call ./mill.bat -i "native.copyToArtifacts" artifacts/
         shell: cmd
         if: runner.os == 'Windows'
-      - uses: actions/upload-artifact@v3.1.2
+      - uses: actions/upload-artifact@v4
         with:
           name: launcher-${{ matrix.os }}
           path: artifacts/
@@ -112,7 +112,7 @@ jobs:
           ./generate.sh && \
           ./mill -i "tests.test.nativeStatic" && \
           ./mill -i "native-static.copyToArtifacts" artifacts/
-      - uses: actions/upload-artifact@v3.1.2
+      - uses: actions/upload-artifact@v4
         with:
           name: launcher-${{ matrix.os }}-static
           path: artifacts/
@@ -145,7 +145,7 @@ jobs:
           ./generate.sh && \
           ./mill -i "tests.test.nativeStatic" && \
           ./mill -i "native-mostly-static.copyToArtifacts" artifacts/
-      - uses: actions/upload-artifact@v3.1.2
+      - uses: actions/upload-artifact@v4
         with:
           name: launcher-${{ matrix.os }}-mostly-static
           path: artifacts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -129,7 +129,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - uses: VirtusLab/scala-cli-setup@9bc68588ab2d49dae03e5395a5f411e20914f97e
+      - uses: VirtusLab/scala-cli-setup@v1
         with:
           jvm: "temurin:17"
       - uses: actions/setup-node@v4
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - uses: VirtusLab/scala-cli-setup@9bc68588ab2d49dae03e5395a5f411e20914f97e
+      - uses: VirtusLab/scala-cli-setup@v1
         with:
           jvm: "temurin:17"
       - run: .github/scripts/gpg-setup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
           submodules: true
       - uses: coursier/cache-action@v6.4
-      - uses: coursier/setup-action@v1.2.0-M3
+      - uses: coursier/setup-action@v1
         with:
           jvm: temurin:17
       - uses: actions/setup-node@v4
@@ -101,7 +101,7 @@ jobs:
           fetch-depth: 0
           submodules: true
       - uses: coursier/cache-action@v6.4
-      - uses: coursier/setup-action@v1.2.0-M3
+      - uses: coursier/setup-action@v1
         with:
           jvm: temurin:17
       - uses: actions/setup-node@v4
@@ -134,7 +134,7 @@ jobs:
           fetch-depth: 0
           submodules: true
       - uses: coursier/cache-action@v6.4
-      - uses: coursier/setup-action@v1.2.0-M3
+      - uses: coursier/setup-action@v1
         with:
           jvm: temurin:17
       - uses: actions/setup-node@v4

--- a/build.sc
+++ b/build.sc
@@ -97,7 +97,7 @@ trait ScalaJsCliNativeImage extends ScalaModule with NativeImage {
     )
   }
   def nativeImagePersist = System.getenv("CI") != null
-  def graalVmVersion = "22.3.3"
+  def graalVmVersion = "22.3.1"
   def nativeImageGraalVmJvmId = s"graalvm-java17:$graalVmVersion"
   def nativeImageName = "scala-js-ld"
   def moduleDeps = Seq(


### PR DESCRIPTION
We need to bump artifact actions to v4+ to prevent CI from failing on dropped versions, like in https://github.com/VirtusLab/scala-js-cli/actions/runs/12930400417/job/36061927532#step:1:36

Refer to https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Before this change, the error we were getting:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3.1.2`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

action bumps:
- `actions/checkout` to v4
- `actions/upload-artifact` to v4
- `VirtusLab/scala-cli-setup` to v1

other:
- add `macos-13` to the matrix (we ran on `macos-latest` only, so aarch64)