### PR TITLE
Fix formatting configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           submodules: true
       - uses: VirtusLab/scala-cli-setup@v1
       - run: scala-cli fmt . --check
+      - run: ./mill -i mill.scalalib.scalafmt/checkFormatAll
 
   scalafix:
     timeout-minutes: 15

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 .metals
 .vscode
 .bloop
+.scala-build

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -14,6 +14,15 @@ newlines.alwaysBeforeElseAfterCurlyIf = true
 
 runner.dialect = scala213
 
+fileOverride {
+  "glob:**/*.mill" {
+    runner.dialect = scala3
+  }
+  "glob:**/*.sc" {
+    runner.dialect = scala3
+  }
+}
+
 rewrite.rules = [
   RedundantBraces
   RedundantParens

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -12,7 +12,7 @@ newlines.beforeMultiline = keep
 newlines.afterCurlyLambdaParams = keep
 newlines.alwaysBeforeElseAfterCurlyIf = true
 
-runner.dialect = scala3
+runner.dialect = scala213
 
 rewrite.rules = [
   RedundantBraces

--- a/cli/src/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/org/scalajs/cli/Scalajsld.scala
@@ -153,8 +153,9 @@ object Scalajsld {
       opt[String]("moduleSplitStyle")
         .action((x, c) => c.copy(moduleSplitStyle = x))
         .text(
-          "Module splitting style " + ModuleSplitStyleRead.All
-            .mkString("(", ", ", ")")
+          "Module splitting style " +
+            ModuleSplitStyleRead.All
+              .mkString("(", ", ", ")")
         )
       opt[Seq[String]]("smallModuleForPackages")
         .valueName("<package1>,<package2>...")


### PR DESCRIPTION
Smh we've been formating this with `scala3` as dialect, even though it's a Scala 2.13 project 🤦 
`scala3` should only apply to `*.mill` build files here.